### PR TITLE
Fixing bug with bower

### DIFF
--- a/FontawesomeAsset.php
+++ b/FontawesomeAsset.php
@@ -7,7 +7,7 @@ use yii\web\AssetBundle;
 class FontawesomeAsset extends AssetBundle
 {
     /** @var string */
-    public $sourcePath = '@bower/fontawesome';
+    public $sourcePath = '@bower/font-awesome';
     /** @var array */
     public $depends = [
         'yii\bootstrap\BootstrapAsset'


### PR DESCRIPTION
For some reason it does not work after composer update:

> Invalid Parameter – yii\base\InvalidParamException
> 
> The file or directory to be published does not exist: C:\projects\heavyCMS/vendor\bower/fontawesome

The fix is to rename `fontawesome` to 'font-awesome'